### PR TITLE
fix(setting):アバター画像が写真アイコンとかぶっている問題解決

### DIFF
--- a/src/app/user/user/user.component.html
+++ b/src/app/user/user/user.component.html
@@ -3,11 +3,11 @@
     <ng-container *ngIf="creator$ | async as creator">
       <h2 class="course__title">ユーザー</h2>
       <section class="avatar-section">
+        <p>アバター画像</p>
         <label
           class="avatar-wrapper"
           [class.avatar-wrapper--nouser]="!isMyAccount"
         >
-          <p>アバター画像</p>
           <img
             class="avatar"
             [src]="imageFile ? imageFile : creator.avatarUrl"

--- a/src/app/user/user/user.component.scss
+++ b/src/app/user/user/user.component.scss
@@ -75,6 +75,9 @@ button {
   display: block;
   position: relative;
   margin: 0 auto 16px;
+  &__avatar-img {
+    padding-bottom: 8px;
+  }
   &::before {
     font-family: 'Material Icons';
     content: '\e439';
@@ -104,6 +107,7 @@ button {
   position: relative;
   margin: 0 auto 16px;
   border-radius: 50%;
+  padding-top: 4px;
 }
 
 .crop {


### PR DESCRIPTION
アバター画像が写真アイコンとかぶっている問題、解決しました！

## Before
![image](https://user-images.githubusercontent.com/66728424/107602591-682dd000-6c6d-11eb-9eac-ccd48c3f2a70.png)

## After
![image](https://user-images.githubusercontent.com/66728424/107602654-98756e80-6c6d-11eb-9fc4-7e7dea416708.png)

ご確認お願いします！