### PR TITLE
入力時のヒント追加・スタート画面に戻るボタン削除

### DIFF
--- a/src/app/create-course/create-course/create-course.component.html
+++ b/src/app/create-course/create-course/create-course.component.html
@@ -90,7 +90,7 @@
                     matInput
                     autocomplete="off"
                     formControlName="inputHint"
-                    placeholder="カタカナ・ひらがな・数字...で入力"
+                    placeholder="「カタカナで入力してね」など"
                   />
                 </mat-form-field>
                 <mat-form-field>

--- a/src/app/create-course/create-course/create-course.component.html
+++ b/src/app/create-course/create-course/create-course.component.html
@@ -85,6 +85,15 @@
                   />
                 </mat-form-field>
                 <mat-form-field>
+                  <mat-label>入力形式のヒント</mat-label>
+                  <input
+                    matInput
+                    autocomplete="off"
+                    formControlName="inputHint"
+                    placeholder="カタカナ・ひらがな・数字...で入力"
+                  />
+                </mat-form-field>
+                <mat-form-field>
                   <mat-label>答え</mat-label>
                   <input
                     matInput

--- a/src/app/create-course/create-course/create-course.component.ts
+++ b/src/app/create-course/create-course/create-course.component.ts
@@ -79,6 +79,7 @@ export class CreateCourseComponent implements OnInit {
             [Validators.required, Validators.maxLength(this.maxTitleLength)],
           ],
           hint: ['', [Validators.maxLength(this.maxTitleLength)]],
+          inputHint: ['', [Validators.maxLength(this.maxTitleLength)]],
           answer: [
             '',
             [Validators.required, Validators.maxLength(this.maxTitleLength)],
@@ -90,6 +91,7 @@ export class CreateCourseComponent implements OnInit {
             [Validators.required, Validators.maxLength(this.maxTitleLength)],
           ],
           hint: ['', [Validators.maxLength(this.maxTitleLength)]],
+          inputHint: ['', [Validators.maxLength(this.maxTitleLength)]],
           answer: [
             '',
             [Validators.required, Validators.maxLength(this.maxTitleLength)],
@@ -101,6 +103,7 @@ export class CreateCourseComponent implements OnInit {
             [Validators.required, Validators.maxLength(this.maxTitleLength)],
           ],
           hint: ['', [Validators.maxLength(this.maxTitleLength)]],
+          inputHint: ['', [Validators.maxLength(this.maxTitleLength)]],
           answer: [
             '',
             [Validators.required, Validators.maxLength(this.maxTitleLength)],

--- a/src/app/interfaces/question.ts
+++ b/src/app/interfaces/question.ts
@@ -2,6 +2,7 @@ export interface Question {
   text: string;
   title: string;
   hint?: string;
+  inputHint?: string;
   answer: string;
   mapPosition: google.maps.LatLngLiteral;
   imageURL?: string;

--- a/src/app/play-course/question/question.component.html
+++ b/src/app/play-course/question/question.component.html
@@ -50,9 +50,6 @@
 
       <div class="question__footer">
         <button mat-button routerLink="/">コース選択に戻る</button>
-        <!-- <button mat-button [routerLink]="['/course', courseId]">
-          スタート画面に戻る
-        </button> -->
       </div>
     </ng-container>
   </div>

--- a/src/app/play-course/question/question.component.html
+++ b/src/app/play-course/question/question.component.html
@@ -19,7 +19,11 @@
             <mat-form-field appearance="outline">
               <mat-label>答えを入力</mat-label>
               <input [formControl]="answerCtrl" matInput autocomplete="off" />
+              <mat-hint *ngIf="question.inputHint">{{
+                question.inputHint
+              }}</mat-hint>
             </mat-form-field>
+
             <div class="question__action">
               <button
                 class="question__btn"
@@ -46,9 +50,9 @@
 
       <div class="question__footer">
         <button mat-button routerLink="/">コース選択に戻る</button>
-        <button mat-button [routerLink]="['/course', 'fafafa']">
+        <!-- <button mat-button [routerLink]="['/course', courseId]">
           スタート画面に戻る
-        </button>
+        </button> -->
       </div>
     </ng-container>
   </div>


### PR DESCRIPTION
close #83 
close #82 

入力時のヒントを追加して、スタート画面に戻るボタンを削除しました。ご確認お願いいたします！
- プレイ画面
![image](https://user-images.githubusercontent.com/60844124/107604712-45eb8080-6c74-11eb-89e6-72116ec8be5c.png)
- 作成画面
![image](https://user-images.githubusercontent.com/60844124/107604730-4f74e880-6c74-11eb-9c9a-3874c3d7349f.png)
- プレイスホルダー
![image](https://user-images.githubusercontent.com/60844124/107604762-6f0c1100-6c74-11eb-9fb0-991ba2f913a8.png)
